### PR TITLE
fix(pubspec.yaml)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: unifit
-description: 'Unifit: A fitness app for college students.'.
+description: 'Unifit: A fitness app for college students.'
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev


### PR DESCRIPTION
Comments:
- Flutter doctor was returning an error due additional string ".", after description comment
- Removing "." was enough to fix the issue